### PR TITLE
Fix Pages subpath data loading and improve error visibility

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -20,6 +20,9 @@ async function initializeApp() {
         // Load all data using dataLoader
         console.log('📥 Loading data...');
         const allData = await dataLoader.loadAll();
+        if (allData?.hasFatalError) {
+            throw new Error(allData.error || '数据加载失败：请检查数据文件路径与 GitHub Pages 子路径配置');
+        }
         console.log('✅ Data loaded:', {
             newsCount: allData.news?.count || 0,
             skillsCount: allData.skills?.count || 0,

--- a/js/data-loader.js
+++ b/js/data-loader.js
@@ -6,7 +6,7 @@
 
 class DataLoader {
     constructor() {
-        this.basePath = '/data';
+        this.basePath = 'data';
         this.cache = new Map();
         this.cacheTimeout = 5 * 60 * 1000; // 5 minutes
     }
@@ -83,8 +83,8 @@ class DataLoader {
      */
     async loadNews(month = null) {
         try {
-            // Load from root directory instead of /data/news/
-            const newsData = await this.loadJSON('/news-data.json');
+            // Use relative path so GitHub Pages project sites (/repo-name/) work correctly
+            const newsData = await this.loadJSON('news-data.json');
 
             return {
                 month: month || 'unknown',
@@ -191,8 +191,8 @@ class DataLoader {
      */
     async loadAllSkills() {
         try {
-            // Load from root directory instead of /data/skills/
-            const skillsData = await this.loadJSON('/skills-data.json');
+            // Use relative path so GitHub Pages project sites (/repo-name/) work correctly
+            const skillsData = await this.loadJSON('skills-data.json');
 
             return {
                 skills: skillsData.skills || [],
@@ -223,8 +223,8 @@ class DataLoader {
         try {
             // Direct load from root directory, bypassing loadAllNews and loadAllSkills
             const [newsData, skillsData] = await Promise.all([
-                this.loadJSON('/news-data.json'),
-                this.loadJSON('/skills-data.json')
+                this.loadJSON('news-data.json'),
+                this.loadJSON('skills-data.json')
             ]);
 
             return {
@@ -256,6 +256,7 @@ class DataLoader {
                 categories: {},
                 news: { items: [], count: 0, errors: [error.message] },
                 skills: { skills: [], categories: {}, count: 0, errors: [error.message] },
+                hasFatalError: true,
                 error: error.message,
                 timestamp: new Date().toISOString()
             };

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -191,3 +191,23 @@ def test_javascript_template_literals(index_html_content: str):
         or 'src="js/renderers/skills-renderer.js"' in index_html_content
     )
     assert has_renderers, "Missing external JS renderers that should use template literals"
+
+
+def test_data_loader_uses_relative_paths_for_pages_project_sites():
+    """Data loader should avoid absolute-root JSON paths for GitHub Pages project deployments."""
+    loader_path = "js/data-loader.js"
+    with open(loader_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    forbidden_patterns = [
+        "loadJSON('/news-data.json')",
+        "loadJSON('/skills-data.json')",
+        "basePath = '/data'",
+    ]
+
+    for pattern in forbidden_patterns:
+        assert pattern not in content, f"Found absolute path pattern that breaks project-site deploys: {pattern}"
+
+    assert "loadJSON('news-data.json')" in content
+    assert "loadJSON('skills-data.json')" in content
+    assert "basePath = 'data'" in content


### PR DESCRIPTION
### Motivation
- Absolute-root JSON fetches break GitHub Pages project-site deployments because the repo subpath (e.g. `/repo-name/`) is omitted, causing 404s and empty UI.;
- When `loadAll()` failed previously the app could silently show empty states instead of surfacing a clear error to users;
- A regression test is needed to prevent accidental reintroduction of absolute-root data paths that break project-site hosting.

### Description
- Changed data paths to be relative by updating `this.basePath` from `/data` to `data` and replacing `loadJSON('/news-data.json')` / `loadJSON('/skills-data.json')` with `loadJSON('news-data.json')` / `loadJSON('skills-data.json')` in `js/data-loader.js`.
- Added a fatal error marker (`hasFatalError`) in the `loadAll()` catch branch so that loader failures are distinguishable from empty-but-successful loads in `js/data-loader.js`.
- Surfaces loader failures in app initialization by detecting `allData?.hasFatalError` and throwing so `showErrorState()` renders a visible error in `js/app.js`.
- Added a regression test `test_data_loader_uses_relative_paths_for_pages_project_sites` in `tests/test_javascript.py` to assert the absence of absolute-root patterns and the presence of the new relative-path patterns.

### Testing
- Ran `pytest -q tests/test_javascript.py` and all tests passed (`17 passed, 1 warning`).
- Launched a local server with `python -m http.server 4173` and ran a Playwright script that navigated to `http://127.0.0.1:4173/index.html` and captured a screenshot showing news cards rendered successfully.
- No automated tests failed during validation; the new regression test confirmed the relative-path changes are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698719281b0c8332abe0016072a3eac2)